### PR TITLE
Refactor and resolve warning-creating messages, mainly by using dplyr::recode_values

### DIFF
--- a/00_rerun-main-scripts.sh
+++ b/00_rerun-main-scripts.sh
@@ -3,8 +3,8 @@
 # Rscript 02_download-cces-dataverse.R || exit 1
 # Rscript 03_read-common.R || exit 1
 # Rscript 04_prepare-fixes.R || exit 1
-Rscript 05_stack-cumulative.R || exit 1
-# Rscript 06_extract-politicians.R || exit 1
+# Rscript 05_stack-cumulative.R || exit 1
+Rscript 06_extract-politicians.R || exit 1
 
 # TEST-GUIDE mode: writes only the guide feather (~7x faster). Drop CCES_TEST_GUIDE=1 for a full release build (all .rds/.dta outputs).
 CCES_TEST_GUIDE=1 Rscript 07_merge-contextual_upload.R || exit 1

--- a/00_rerun-main-scripts.sh
+++ b/00_rerun-main-scripts.sh
@@ -4,8 +4,10 @@
 # Rscript 03_read-common.R || exit 1
 # Rscript 04_prepare-fixes.R || exit 1
 Rscript 05_stack-cumulative.R || exit 1
-Rscript 06_extract-politicians.R || exit 1
-Rscript 07_merge-contextual_upload.R || exit 1
+# Rscript 06_extract-politicians.R || exit 1
+
+# TEST-GUIDE mode: writes only the guide feather (~7x faster). Drop CCES_TEST_GUIDE=1 for a full release build (all .rds/.dta outputs).
+CCES_TEST_GUIDE=1 Rscript 07_merge-contextual_upload.R || exit 1
 # Rscript 07_format-crunch.R || exit 1
-# quarto render guide/guide_cumulative_2006-2025.qmd || exit 1
+quarto render guide/guide_cumulative_2006-2025.qmd || exit 1
 

--- a/04_prepare-fixes.R
+++ b/04_prepare-fixes.R
@@ -8,7 +8,13 @@ load("data/output/01_responses/common_all.RData")
 
 
 # Retrieve 2007 County -----
+cc07_county <- cc07 |>
+  select(year, case_id, county_fips = CC06_V1004) |>
+  mutate_all(zap_labels)
 
+# Retrieve 2017 County -----
+cc17_county <- read_csv("data/source/cces/CCES17_Common_county.csv", show_col_types = FALSE) |>
+  transmute(year = 2017, case_id = V101, countyfips)
 
 # Retrieve 2010 PID  -------
 pid3_cc10 <- cc10 |>
@@ -59,6 +65,8 @@ cc06_interest <- cc06 |>
             interest = as.integer(v2042))
 
 # save ---------
+write_rds(cc07_county, "data/output/01_responses/cc07_county.Rds")
+write_rds(cc17_county, "data/output/01_responses/cc17_county.Rds")
 write_rds(pid3_cc10, "data/output/01_responses/cc10_pid3.Rds")
 write_rds(econ_recoded, "data/output/01_responses/cc09_econ_retro.Rds")
 write_rds(cc06_time, "data/output/01_responses/cc06_datetime.Rds")

--- a/05_functions-stack.R
+++ b/05_functions-stack.R
@@ -98,6 +98,140 @@ finalize_economy_retro <- function(tbl) {
     select(year, case_id, economy_retro)
 }
 
+finalize_faminc <- function(inc_old_raw, inc_new_raw) {
+  inc_old <- inc_old_raw |>
+    mutate(faminc = recode_values(
+      family_income_old,
+      1 ~ "Less than 10k",
+      c(2, 3) ~ "10k - 20k",
+      c(4, 5) ~ "20k - 30k",
+      6 ~ "30k - 40k",
+      7 ~ "40k - 50k",
+      8 ~ "50k - 60k",
+      9 ~ "60k - 70k",
+      10 ~ "70k - 80k",
+      11 ~ "80k - 100k",
+      12 ~ "100k - 120k",
+      13 ~ "120k - 150k",
+      14 ~ "150k+",
+      15 ~ "Prefer not to say"))
+
+  inc_new <- inc_new_raw |>
+    mutate(faminc = recode_values(
+      family_income,
+      1  ~ "Less than 10k",
+      2  ~ "10k - 20k",
+      3  ~ "20k - 30k",
+      4  ~ "30k - 40k",
+      5  ~ "40k - 50k",
+      6  ~ "50k - 60k",
+      7  ~ "60k - 70k",
+      8  ~ "70k - 80k",
+      9  ~ "80k - 100k",
+      10 ~ "100k - 120k",
+      11 ~ "120k - 150k",
+      c(12:16, 31, 32) ~ "150k+",
+      97 ~ "Prefer not to say",
+      98 ~ "Skipped",
+      99 ~ "Not Asked"))
+
+  inner_join(inc_old, inc_new, by = c("year", "case_id"),
+             relationship = "one-to-one") |>
+    mutate(faminc_char = coalesce(faminc.x, faminc.y),
+           faminc_num = coalesce(family_income_old, family_income)) |>
+    transmute(year, case_id, faminc = fct_reorder(faminc_char, faminc_num, .na_rm = FALSE))
+}
+
+finalize_union <- function(tbl) {
+  tbl |>
+    mutate(union = labelled(
+      zap_label(union),
+      c("Yes, Currently" = 1,
+        "Yes, Formerly" = 2,
+        "No, Never" = 3)),
+      union = na_if(union, 8))
+}
+
+finalize_union_hh <- function(tbl) {
+  tbl |>
+    mutate(union_hh = fct_collapse(
+      unionhh,
+      `1` = c(
+        "Current Member in Household",
+        "Yes, a Member of My Household Is Currently a Union Member"),
+      `2` = c(
+        "A Member of My Household Was Formerly a Member of a Labor Union, But Is not Now",
+        "Former Member in Household"),
+      `3` = c(
+        "No Union Members in Household",
+        "No, No One in My Household Has Ever Been a Member of a Labor Union"),
+      `4` = c("Not Sure")
+    )) |>
+    mutate(union_hh = labelled(
+      as.integer(union_hh),
+      c("Yes, Currently" = 1,
+        "Yes, Formerly" = 2,
+        "No, Never" = 3,
+        "Not Sure" = 4))) |>
+    select(-unionhh)
+}
+
+finalize_pid3_leaner <- function(tbl) {
+  leaner_lbl_code <- c(`Democrat (Including Leaners)` = 1L,
+                       `Republican (Including Leaners)` = 2L,
+                       `Independent (Excluding Leaners)` = 3L,
+                       `Not Sure` = 8L)
+  tbl |>
+    mutate(pid3_leaner = as_factor(pid7)) |>
+    mutate(pid3_leaner = fct_collapse(pid3_leaner,
+                                      "Republican (Including Leaners)" = c("Strong Republican", "Not Very Strong Republican", "Lean Republican"),
+                                      "Democrat (Including Leaners)" = c("Strong Democrat", "Not Very Strong Democrat", "Lean Democrat"),
+                                      "Independent (Excluding Leaners)" = "Independent")) |>
+    mutate(pid3_leaner_num = recode(pid3_leaner, !!!leaner_lbl_code)) |>
+    mutate(pid3_leaner = labelled(pid3_leaner_num, leaner_lbl_code)) |>
+    select(-pid3_leaner_num, -pid7)
+}
+
+# shared Yes/Selected/No/Not Selected collapse used by milstat and healthins
+recode_selected <- function(vec) {
+  recode_factor(vec,
+                Yes = "Yes",
+                Selected = "Yes",
+                No = "No",
+                `Not Selected` = "No")
+}
+
+finalize_milstat <- function(tbl) {
+  tbl |>
+    rename(no_milstat = milstat_5) |>
+    mutate(no_milstat = recode_selected(no_milstat))
+}
+
+finalize_healthins <- function(hi_most_raw, hi_18_raw) {
+  hi_most <- hi_most_raw |>
+    filter(year != "2018") |>
+    rename(no_healthins = healthins_6)
+  hi_18 <- hi_18_raw |>
+    rename(no_healthins = healthins_7)
+
+  bind_rows(hi_most, hi_18) |>
+    mutate(no_healthins = recode_selected(no_healthins))
+}
+
+finalize_marstat <- function(tbl) {
+  tbl |>
+    remove_value_labels(marstat = 8) |>
+    mutate(marstat = na_if(marstat, 8)) |>
+    labelled::add_value_labels(marstat = c(`Single / Never Married` = 5))
+}
+
+finalize_citizen <- function(tbl) {
+  tbl |>
+    mutate(citizen = str_detect(immstat, regex("(Non-Citizen|Not A Citizen)", ignore_case = TRUE))) |>
+    mutate(citizen = labelled(citizen + 1, labels = c(`Citizen` = 1, `Non-Citizen` = 2))) |>
+    select(-immstat)
+}
+
 #' name standardization
 std_name <- function(tbl, is_panel = FALSE) {
   cces_year <- as.integer(unique(tbl$year))

--- a/05_functions-stack.R
+++ b/05_functions-stack.R
@@ -1392,128 +1392,103 @@ std_vvv <- function(vec, varname, yrvec) {
   recoded
 }
 
+collapse_pres_values <- function(vec, ..., levels, na_values = character()) {
+  if (is.factor(vec)) {
+    source_values <- levels(vec)
+    key <- str_trim(source_values)
+    if (length(na_values) > 0) key <- replace(key, key %in% na_values, NA_character_)
+    key <- recode_values(key, ..., default = key)
+    out <- key[as.integer(vec)]
+    observed <- unique(key[!is.na(key)])
+  } else {
+    x <- as.character(vec)
+    source_values <- unique(x)
+    key <- str_trim(source_values)
+    if (length(na_values) > 0) key <- replace(key, key %in% na_values, NA_character_)
+    key <- recode_values(key, ..., default = key)
+    out <- key[match(x, source_values)]
+    observed <- unique(out[!is.na(out)])
+  }
+
+  factor(out, levels = c(intersect(levels, observed), setdiff(observed, levels)))
+}
+
 #' Fix for voted08
 clps_pres08 <- function(vec) {
-  vec |>
-    na_if("Did not Vote") |> # means did not turnout until 2011 and 2012
-    as.character() |>
-    str_trim() |>
-    as_factor() |>
-    fct_collapse(
-      `Barack Obama` = c("Barack Obama",
-                         "Barack Obama (Democratic)"),
-      `John McCain` = c("John McCain (Republican)",
-                        "John McCain"),
-      `Other` = c("Someone Else"),
-      `Not Sure` = c("Don't Recall")
-    ) |>
-    fct_relevel("Barack Obama", "John McCain", "Other") |>
-    fct_drop()
+  collapse_pres_values(
+    vec,
+    c("Barack Obama", "Barack Obama (Democratic)") ~ "Barack Obama",
+    c("John McCain", "John McCain (Republican)") ~ "John McCain",
+    "Someone Else" ~ "Other",
+    "Don't Recall" ~ "Not Sure",
+    levels = c("Barack Obama", "John McCain", "Other", "Not Sure"),
+    na_values = "Did not Vote" # means did not turnout until 2011 and 2012
+  )
 }
 
 #' Quick fix for 2012 voted, where labels are too mixed to fix automatically
 clps_pres12 <- function(vec) {
-  vec |>
-    na_if("Not Vote") |> # means did not turnout in 2015
-  fct_collapse(
+  collapse_pres_values(
     vec,
-    `Barack Obama` = c(
-      "Barack Obama",
-      "Barack Obama (Democratic)",
-      "Vote for Barack Obama"),
-    `Mitt Romney` = c(
-      "Mitt Romney",
-      "Mitt Romney (Republican)",
-      "Vote for Mitt Romney"),
-    `Other` = c(
-      "Someone Else",
-      "Vote for Someone Else",
-      "Other"),
-    `Undervote` = c(
-      "Did Not Vote",
-      "Did not Vote",
-      "I Did Not Vote",
-      "I Did not Vote",
-      "Not Vote for this Office",
-      "I Did not Vote in this Race"),
-    `Not Sure` = c("Not Sure", "Don't Recall")
-  ) |>
-    fct_relevel("Barack Obama", "Mitt Romney", "Other", "Undervote")
+    c("Barack Obama", "Barack Obama (Democratic)", "Vote for Barack Obama") ~ "Barack Obama",
+    c("Mitt Romney", "Mitt Romney (Republican)", "Vote for Mitt Romney") ~ "Mitt Romney",
+    c("Someone Else", "Vote for Someone Else", "Other") ~ "Other",
+    c("Did Not Vote", "Did not Vote", "I Did Not Vote",
+      "I Did not Vote", "Not Vote for this Office",
+      "I Did not Vote in this Race") ~ "Undervote",
+    c("Not Sure", "Don't Recall") ~ "Not Sure",
+    levels = c("Barack Obama", "Mitt Romney", "Other", "Undervote", "Not Sure"),
+    na_values = "Not Vote" # means did not turnout in 2015
+  )
 }
 clps_pres16 <- function(vec) {
-  vec |>
-  na_if("Did not Vote for President") |> # these only occur post-2016 and are "did not turn out"
-  fct_collapse(
-    `Hilary Clinton` = c(
-      "Hillary Clinton",
-      "Hillary Clinton (Democrat)"),
-    `Donald Trump` = c(
-      "Donald Trump",
-      "Donald Trump (Republican)"),
-    `Gary Johnson` = c("Gary Johnson (Libertarian)", "Gary Johnson"),
-    `Evan McMullin` = c("Evan Mcmullin (Independent)", "Evan Mcmullin"),
-    `Jill Stein` = c("Jill Stein (Green)", "Jill Stein"),
-    `Other` = c(
-      "Other", "Someone Else"),
-    `Undervote` = c(
-      "I Didn't Vote in this Election",
-      "I Did not Cast a Vote for President"),
-    `Not Sure` = c(
-      "I'm not Sure", "I Don't Recall")
-  ) |>
-    fct_relevel("Hilary Clinton", "Donald Trump", "Gary Johnson", "Evan McMullin",
-                "Jill Stein", "Other", "Undervote")
+  collapse_pres_values(
+    vec,
+    c("Hillary Clinton", "Hillary Clinton (Democrat)") ~ "Hilary Clinton",
+    c("Donald Trump", "Donald Trump (Republican)") ~ "Donald Trump",
+    c("Gary Johnson", "Gary Johnson (Libertarian)") ~ "Gary Johnson",
+    c("Evan Mcmullin", "Evan Mcmullin (Independent)") ~ "Evan McMullin",
+    c("Jill Stein", "Jill Stein (Green)") ~ "Jill Stein",
+    c("Other", "Someone Else") ~ "Other",
+    c("I Didn't Vote in this Election", "I Did not Cast a Vote for President") ~ "Undervote",
+    c("I'm not Sure", "I Don't Recall") ~ "Not Sure",
+    levels = c("Hilary Clinton", "Donald Trump", "Gary Johnson", "Evan McMullin",
+               "Jill Stein", "Other", "Undervote", "Not Sure"),
+    na_values = "Did not Vote for President" # post-2016 and means did not turn out
+  )
 }
 
 clps_pres20 <- function(vec) {
-  vec |>
-    na_if("Did not Vote for President") |> # these mean did not turnout
-    fct_collapse(
-      `Joe Biden` = c(
-      "Joe Biden",
-      "Joe Biden (Democrat)"),
-    `Donald Trump` = c(
-      "Donald Trump",
-      "Donald Trump (Republican)",
-      "Donald J. Trump (Republican)"),
-    `Jo Jorgensen` = "Jo Jorgensen",
-    `Howie Hawkins` = "Howie Hawkins",
-    `Other` = c(
-      "Other",
-      "Someone Else"),
-    `Undervote` = c(
-      "I Did not Vote in this Race",
-      "I Did not Vote"),
-    `Not Sure` = c("I'm not Sure")
-  ) |>
-    fct_relevel("Joe Biden", "Donald Trump", "Jo Jorgensen",
-                "Howie Hawkins", "Other", "Undervote")
+  collapse_pres_values(
+    vec,
+    c("Joe Biden", "Joe Biden (Democrat)") ~ "Joe Biden",
+    c("Donald Trump", "Donald Trump (Republican)", "Donald J. Trump (Republican)") ~ "Donald Trump",
+    "Jo Jorgensen" ~ "Jo Jorgensen",
+    "Howie Hawkins" ~ "Howie Hawkins",
+    c("Other", "Someone Else") ~ "Other",
+    c("I Did not Vote in this Race", "I Did not Vote") ~ "Undervote",
+    "I'm not Sure" ~ "Not Sure",
+    levels = c("Joe Biden", "Donald Trump", "Jo Jorgensen",
+               "Howie Hawkins", "Other", "Undervote", "Not Sure"),
+    na_values = "Did not Vote for President" # means did not turnout
+  )
 }
 
 clps_pres24 <- function(vec) {
-  fct_collapse(
+  collapse_pres_values(
     vec,
-    `Kamala Harris` = c(
-      "Kamala Harris",
-      "Kamala Harris (Democrat)"),
-    `Donald Trump` = c(
-      "Donald Trump",
-      "Donald Trump (Republican)"),
-    `Jill Stein` = "Jill Stein",
-    `Cornel West` = "Cornel West",
-    `Chase Oliver` = "Chase Oliver",
-    `Other` = c(
-      "Other",
-      "Someone Else"),
-    `Undervote` = c(
-      "I Did not Vote in this Race",
-      "I Did not Vote",
-      "Did not Vote for President"), # in 2024 this seems to mean undervote
-    `Not Sure / Don't Recall` = c("I'm not Sure")
-  ) |>
-    fct_relevel("Kamala Harris", "Donald Trump", "Jill Stein",
-                "Robert F. Kennedy, Jr.", "Cornel West", "Chase Oliver",
-                "Other", "Undervote")
+    c("Kamala Harris", "Kamala Harris (Democrat)") ~ "Kamala Harris",
+    c("Donald Trump", "Donald Trump (Republican)") ~ "Donald Trump",
+    "Jill Stein" ~ "Jill Stein",
+    "Cornel West" ~ "Cornel West",
+    "Chase Oliver" ~ "Chase Oliver",
+    c("Other", "Someone Else") ~ "Other",
+    c("I Did not Vote in this Race", "I Did not Vote", "Did not Vote for President") ~ "Undervote",
+    "I'm not Sure" ~ "Not Sure / Don't Recall",
+    levels = c("Kamala Harris", "Donald Trump", "Jill Stein",
+               "Robert F. Kennedy, Jr.", "Cornel West", "Chase Oliver",
+               "Other", "Undervote", "Not Sure / Don't Recall")
+  )
 }
 
 #' give pres party from chars of pres names

--- a/05_functions-stack.R
+++ b/05_functions-stack.R
@@ -1,5 +1,103 @@
 # functions for 05_stack-cumulative.R
 
+# post-extraction helpers ----
+replace_year <- function(tbl, years, replacement) {
+  stopifnot(all(replacement$year %in% years))
+  tbl |>
+    filter(!.data$year %in% years) |>
+    bind_rows(replacement)
+}
+
+finalize_tookpost <- function(tbl) {
+  tbl |>
+    mutate(tookpost = labelled(
+      as.integer(tookpost_num == 1 & year < 2018 |
+                   tookpost_num == 2 & year %in% c(2018, 2020, 2022, 2024)), # diff number in 2018
+      labels = c("Took Post-Election Survey" = 1,
+                 "Did Not Take Post-Election Survey" = 0))) |>
+    mutate(tookpost = replace(tookpost, year %% 2 == 1, NA)) |>
+    select(year, case_id, tookpost)
+}
+
+finalize_pid3 <- function(tbl) {
+  pid3_labels <- c("Democrat" = 1, "Republican" = 2, "Independent" = 3,
+                   "Other" = 4, "Not Sure" = 5)
+
+  tbl |>
+    mutate(pid3_num = na_if(pid3_num, 8)) |>
+    mutate(pid3_num = na_if(pid3_num, 9)) |>
+    mutate(pid3 = labelled(as.integer(pid3_num), pid3_labels)) |>
+    select(year, case_id, pid3)
+}
+
+finalize_intent_turnout <- function(tbl) {
+  intent_turnout_levels <- c(
+    "Yes, definitely",
+    "Probably",
+    "I already voted (early or absentee)",
+    "I plan to vote before Election Day",
+    "No",
+    "Undecided"
+  )
+
+  tbl |>
+    mutate(intent_turnout_self = replace_values(
+      as.character(intent_trn),
+      "Yes, Definitely"                      ~ "Yes, definitely",
+      "I Already Voted (Early or Absentee)"  ~ "I already voted (early or absentee)",
+      c("I Plan to Vote Before November 3rd",
+        "I Plan to Vote Before November 4th",
+        "I Plan to Vote Before November 5th",
+        "I Plan to Vote Before November 6th",
+        "I Plan to Vote Before November 8th") ~ "I plan to vote before Election Day"),
+      intent_turnout_self = factor(intent_turnout_self, levels = intent_turnout_levels)) |>
+    select(-intent_trn)
+}
+
+finalize_voted_turnout <- function(tbl) {
+  tbl |>
+    mutate(voted_turnout_self = case_when(
+      str_detect(voted_trn, regex("Definitely Voted", ignore_case = TRUE)) ~ "Yes",
+      str_detect(voted_trn, regex("yes", ignore_case = TRUE)) ~ "Yes",
+      str_detect(voted_trn, regex("no", ignore_case = TRUE)) ~ "No",
+      str_detect(voted_trn, regex("not sure", ignore_case = TRUE)) ~ "Not Sure",
+      str_detect(voted_trn, regex("Did Not Vote", ignore_case = TRUE)) ~ "No",
+      str_detect(voted_trn, regex("didn't Vote", ignore_case = TRUE)) ~ "No",
+      str_detect(voted_trn, regex("But Didn't", ignore_case = TRUE)) ~ "No",
+      str_detect(voted_trn, regex("But couldn't", ignore_case = TRUE)) ~ "No",
+      str_detect(voted_trn, regex("But Did Not or Could Not", ignore_case = TRUE)) ~ "No",
+      TRUE ~ NA_character_)
+    ) |>
+    mutate(voted_turnout_self = fct_relevel(voted_turnout_self, "Yes", "No")) |>
+    select(-voted_trn)
+}
+
+collapse_economy_retro <- function(tbl) {
+  tbl |>
+    mutate(economy_retro_char = replace_values(
+      economy_retro_char,
+      c("Gotten Worse", "Gotten Somewhat Worse")   ~ "Gotten Worse / Somewhat Worse",
+      c("Gotten Better", "Gotten Somewhat Better") ~ "Gotten Better / Somewhat Better"))
+}
+
+finalize_economy_retro <- function(tbl) {
+  tbl_clean <- tbl |>
+    mutate(economy_retro_char = replace(economy_retro_char, economy_retro_num == 8, NA),
+           economy_retro_num  = na_if(economy_retro_num, 8),
+           economy_retro_char = str_to_lower(economy_retro_char),
+           economy_retro_char = str_replace(economy_retro_char, "^g", "G"),
+           economy_retro_char = str_replace(economy_retro_char, "^s", "S"),
+           economy_retro_char = str_replace(economy_retro_char, "^n", "N"))
+
+  econ_key <- tbl_clean |>
+    distinct(economy_retro_char, economy_retro_num) |>
+    deframe()
+
+  tbl_clean |>
+    mutate(economy_retro = labelled(economy_retro_num, labels = econ_key)) |>
+    select(year, case_id, economy_retro)
+}
+
 #' name standardization
 std_name <- function(tbl, is_panel = FALSE) {
   cces_year <- as.integer(unique(tbl$year))

--- a/05_functions-stack.R
+++ b/05_functions-stack.R
@@ -1102,6 +1102,23 @@ extract_yr <- function(tbl, var, var_name, chr_var_name, num_var_name, is_factor
   }
 }
 
+extract_yr_label_only <- function(tbl, var, var_name, chr_var_name, num_var_name) {
+  if (var_name %in% colnames(tbl)) {
+    select(tbl, year, case_id, !!var) |>
+      mutate(
+        !!chr_var_name := labelled::to_character(.data[[var_name]], levels = "labels"),
+        !!num_var_name := NA_integer_
+      ) |>
+      select(-!!var)
+  } else {
+    select(tbl, year, case_id) |>
+      mutate(
+        !!chr_var_name := NA_character_,
+        !!num_var_name := NA_integer_
+      )
+  }
+}
+
 # takes all datasets available, and given a var, pulls it out of each and stacks
 #'
 #' @param dflist a list of cces datasets. column names need to be standardized.
@@ -1118,11 +1135,17 @@ find_stack <- function(dflist = list(), var, type = "factor", make_labelled = FA
   num_var_name <- paste0(var_name, "_num")
 
   if (type == "factor") {
+    is_vv <- str_detect(var_name, "^vv_")
+
     list_yr <- foreach(yr = 1:length(dflist), .combine = "bind_rows") %do% {
-      extract_yr(dflist[[yr]], enquo(var), var_name, chr_var_name, num_var_name)
+      if (is_vv) {
+        extract_yr_label_only(dflist[[yr]], enquo(var), var_name, chr_var_name, num_var_name)
+      } else {
+        extract_yr(dflist[[yr]], enquo(var), var_name, chr_var_name, num_var_name)
+      }
     }
 
-    if (str_detect(chr_var_name, "^vv_")) { # vv were not displayed questions so can be sorted by frequency, and no numeric left
+    if (is_vv) { # vv were not displayed questions so can be sorted by frequency, and no numeric left
 
       list_yr <- mutate(list_yr,
                         !!chr_var_name := std_vvv(.data[[chr_var_name]], varname = chr_var_name, yrvec = .data[["year"]]))

--- a/05_functions-stack.R
+++ b/05_functions-stack.R
@@ -1261,8 +1261,11 @@ clean_values <- function(tbl, chr_var_name, num_var_name) {
 }
 
 #' custom title case
+#' regexes run on the unique values only, then map back to the full vector,
+#' since survey labels have few distinct values relative to rows
 my_var_case <- function(chr) {
-  str_to_title(chr) |>
+  u <- unique(chr)
+  u_cased <- str_to_title(u) |>
     str_replace_all(" A ", " a ") |>
     str_replace_all(" An ", " an ") |>
     str_replace_all(" About ", " about ") |>
@@ -1284,6 +1287,7 @@ my_var_case <- function(chr) {
     str_replace_all("Only Now and Then", "Only now and then") |>
     str_replace_all("Mccain", "McCain") |>
     str_replace_all("Hardly at All", "Hardly at all")
+  u_cased[match(chr, u)]
 }
 
 

--- a/05_stack-cumulative.R
+++ b/05_stack-cumulative.R
@@ -61,6 +61,14 @@ ccs <- list(
   "2025" = std_name(cc25)
 )
 
+# free the raw per-year objects (~3 GB); everything downstream uses `ccs`.
+# cc08-cc11 are kept until the voted_pres_08 consolidation below.
+# NOTE: this defeats the exists() guard above for interactive re-runs -- the
+# RData reloads each run.
+rm(list = intersect(ls(), c("ccp", "panel12", "cc18_cnew", "hu09",
+                            "cc06", "cc07", paste0("cc", 12:25))))
+invisible(gc())
+
 cli_alert_success("Finished reading in data and standardizing names")
 
 

--- a/05_stack-cumulative.R
+++ b/05_stack-cumulative.R
@@ -29,8 +29,8 @@ cc06_time <- readRDS("data/output/01_responses/cc06_datetime.Rds")
 cc09_time <- readRDS("data/output/01_responses/cc09_datetime.Rds")
 cc10_pid3 <- readRDS("data/output/01_responses/cc10_pid3.Rds")
 cc09_econ <- readRDS("data/output/01_responses/cc09_econ_retro.Rds")
-cc17_county <- read_csv("data/source/cces/CCES17_Common_county.csv", show_col_types = FALSE) |>
-  transmute(year = 2017, case_id = V101, countyfips)
+cc07_county <- readRDS("data/output/01_responses/cc07_county.Rds")
+cc17_county <- readRDS("data/output/01_responses/cc17_county.Rds")
 
 # Create ccs object -----
 # in list form
@@ -91,19 +91,7 @@ pid3 <- finalize_pid3(pid3_fixed)
 pid7 <- find_stack(ccs, pid7, make_labelled = TRUE)
 
 # put leaners into partisans
-leaner_lbl_code <- c(`Democrat (Including Leaners)` = 1L,
-                     `Republican (Including Leaners)` = 2L,
-                     `Independent (Excluding Leaners)` = 3L,
-                     `Not Sure` = 8L)
-pid3_leaner <- pid7 |>
-  mutate(pid3_leaner = as_factor(pid7)) |>
-  mutate(pid3_leaner = fct_collapse(pid3_leaner,
-                                    "Republican (Including Leaners)" = c("Strong Republican", "Not Very Strong Republican", "Lean Republican"),
-                                    "Democrat (Including Leaners)" = c("Strong Democrat", "Not Very Strong Democrat", "Lean Democrat"),
-                                    "Independent (Excluding Leaners)" = "Independent")) |>
-  mutate(pid3_leaner_num = recode(pid3_leaner, !!!leaner_lbl_code)) |>
-  mutate(pid3_leaner = labelled(pid3_leaner_num, leaner_lbl_code)) |>
-  select(-pid3_leaner_num, -pid7)
+pid3_leaner <- finalize_pid3_leaner(pid7)
 
 ideo5 <- find_stack(ccs, ideo5)
 
@@ -131,77 +119,16 @@ age <- find_stack(ccs, age, "integer")
 
 ## income wrangling -----
 cli_h1("Joining income and employment")
-inc_old <- find_stack(ccs, family_income_old, "integer", make_labelled = FALSE) |>
-  mutate(faminc = recode_values(
-    family_income_old,
-    1 ~ "Less than 10k",
-    c(2, 3) ~ "10k - 20k",
-    c(4, 5) ~ "20k - 30k",
-    6 ~ "30k - 40k",
-    7 ~ "40k - 50k",
-    8 ~ "50k - 60k",
-    9 ~ "60k - 70k",
-    10 ~ "70k - 80k",
-    11 ~ "80k - 100k",
-    12 ~ "100k - 120k",
-    13 ~ "120k - 150k",
-    14 ~ "150k+",
-    15 ~ "Prefer not to say"))
-
-inc_new <- find_stack(ccs, family_income, "integer", make_labelled = FALSE) |>
-  mutate(faminc = recode_values(
-    family_income,
-    1  ~ "Less than 10k",
-    2  ~ "10k - 20k",
-    3  ~ "20k - 30k",
-    4  ~ "30k - 40k",
-    5  ~ "40k - 50k",
-    6  ~ "50k - 60k",
-    7  ~ "60k - 70k",
-    8  ~ "70k - 80k",
-    9  ~ "80k - 100k",
-    10 ~ "100k - 120k",
-    11 ~ "120k - 150k",
-    c(12:16, 31, 32) ~ "150k+",
-    97 ~ "Prefer not to say",
-    98 ~ "Skipped",
-    99 ~ "Not Asked"))
-
-faminc <- inner_join(inc_old, inc_new, by = c("year", "case_id")) |>
-  mutate(faminc_char = coalesce(faminc.x, faminc.y),
-         faminc_num = coalesce(family_income_old, family_income)) |>
-  transmute(year, case_id, faminc = fct_reorder(faminc_char, faminc_num, .na_rm = FALSE))
+inc_old_raw <- find_stack(ccs, family_income_old, "integer", make_labelled = FALSE)
+inc_new_raw <- find_stack(ccs, family_income, "integer", make_labelled = FALSE)
+faminc <- finalize_faminc(inc_old_raw, inc_new_raw)
 
 ## union, employment, health ----
-union <- find_stack(ccs, union, make_labelled = TRUE) |>
-  mutate(union = labelled(
-    zap_label(union),
-    c("Yes, Currently" = 1,
-      "Yes, Formerly" = 2,
-      "No, Never" = 3)),
-    union = na_if(union, 8))
+union_raw <- find_stack(ccs, union, make_labelled = TRUE)
+union <- finalize_union(union_raw)
 
-union_hh <- find_stack(ccs, unionhh, make_labelled = FALSE) |>
-  mutate(union_hh = fct_collapse(
-    unionhh,
-    `1` = c(
-      "Current Member in Household",
-      "Yes, a Member of My Household Is Currently a Union Member"),
-    `2` = c(
-      "A Member of My Household Was Formerly a Member of a Labor Union, But Is not Now",
-      "Former Member in Household"),
-    `3` = c(
-      "No Union Members in Household",
-      "No, No One in My Household Has Ever Been a Member of a Labor Union"),
-    `4` = c("Not Sure")
-  )) |>
-  mutate(union_hh = labelled(
-    as.integer(union_hh),
-    c("Yes, Currently" = 1,
-      "Yes, Formerly" = 2,
-      "No, Never" = 3,
-      "Not Sure" = 4))) |>
-  select(-unionhh)
+union_hh_raw <- find_stack(ccs, unionhh, make_labelled = FALSE)
+union_hh <- finalize_union_hh(union_hh_raw)
 
 
 employ <- find_stack(ccs, employ)
@@ -210,37 +137,20 @@ invst <- find_stack(ccs, investor)
 
 child18 <- find_stack(ccs, child18) |>
   rename(has_child = child18)
-milstat <- find_stack(ccs, milstat_5) |>
-  rename(no_milstat = milstat_5) |>
-  mutate(no_milstat = recode_factor(no_milstat,
-                                    Yes = "Yes",
-                                    Selected = "Yes",
-                                    No = "No",
-                                    `Not Selected` = "No"))
+milstat_raw <- find_stack(ccs, milstat_5)
+milstat <- finalize_milstat(milstat_raw)
 
-hi_most <- find_stack(ccs, healthins_6) |>
-  filter(year != "2018") |>
-  rename(no_healthins = healthins_6)
-hi_18 <- find_stack(ccs[c("2018", "2018comp")], healthins_7) |>
-  rename(no_healthins = healthins_7)
-healthins <- bind_rows(hi_most, hi_18) |>
-  mutate(no_healthins = recode_factor(no_healthins,
-                                      Yes = "Yes",
-                                      Selected = "Yes",
-                                      No = "No",
-                                      `Not Selected` = "No"))
+hi_most_raw <- find_stack(ccs, healthins_6)
+hi_18_raw <- find_stack(ccs[c("2018", "2018comp")], healthins_7)
+healthins <- finalize_healthins(hi_most_raw, hi_18_raw)
 
 ## marriage status
-marstat <- find_stack(ccs, marstat, make_labelled = TRUE) |>
-  remove_value_labels(marstat = 8) |>
-  mutate(marstat = na_if(marstat, 8)) |>
-  labelled::add_value_labels(marstat = c(`Single / Never Married` = 5))
+marstat_raw <- find_stack(ccs, marstat, make_labelled = TRUE)
+marstat <- finalize_marstat(marstat_raw)
 
 # citizen - define by immstat
-citizen <- find_stack(ccs, immstat) |>
-  mutate(citizen = str_detect(immstat, regex("(Non-Citizen|Not A Citizen)", ignore_case = TRUE))) |>
-  mutate(citizen = labelled(citizen + 1, labels = c(`Citizen` = 1, `Non-Citizen` = 2))) |>
-  select(-immstat)
+citizen_raw <- find_stack(ccs, immstat)
+citizen <- finalize_citizen(citizen_raw)
 
 
 ## religion -----
@@ -266,14 +176,6 @@ intent_trn <- finalize_intent_turnout(intent_trn_raw)
 
 voted_trn_raw <- find_stack(ccs, voted_trn, type = "factor")
 voted_trn <- finalize_voted_turnout(voted_trn_raw)
-
-# checks before deleting
-intent_trn_raw |>
-  left_join(intent_trn, by = join_by(year, case_id), relationship = "one-to-one") |>
-  count(intent_turnout_self, intent_trn)
-voted_trn_raw |>
-  left_join(voted_trn, by = join_by(year, case_id), relationship = "one-to-one") |>
-  count(voted_turnout_self, voted_trn)
 
 ## validated vote turnout -----
 vv_regstatus <- find_stack(ccs, vv_regstatus, new_reorder = FALSE) # will reorder by frequency later
@@ -406,16 +308,11 @@ zipcode <- find_stack(ccs, zipcode, "character") |>
   mutate(zipcode = str_pad(zipcode, width = 5, pad = "0"))
 
 county_fips_raw <- find_stack(ccs, county_fips, "numeric")
-county_fips_fixed <- county_fips_raw |>
+county_fips <- county_fips_raw |>
   left_join2(cc17_county) |>
   mutate(county_fips = coalesce(county_fips, as.numeric(countyfips))) |>
-  select(-countyfips)
-county_fips <- replace_year(
-  county_fips_fixed,
-  2007,
-  select(cc07, year, case_id, county_fips = CC06_V1004) |>
-    mutate_all(zap_labels)
-)
+  select(-countyfips) |>
+  replace_year(2007, cc07_county)
 
 dist <- find_stack(ccs, dist, "integer")
 dist_up <- find_stack(ccs, dist_up, "integer")
@@ -537,24 +434,20 @@ addon_id <- bind_rows(panel_id, comp_id) # hu08_id, hu09_id,
 # Weight --
 size_year <- ccc |>
   anti_join(addon_id, by = c("year", "case_id")) |> # don't count panel to get weights
-  group_by(year) |>
-  summarize(size = n()) |>
+  summarize(size = n(), .by = year) |>
   mutate(size_factor = size / median(size)) # manageable constant -- divide by median
 
 ccc_sort <- ccc |>
   left_join(select(size_year, year, size_factor), by = c("year"), relationship = "many-to-one") |>
-  mutate(weight_cumulative = weight / size_factor) |>
-  select(-size_factor) |>
+  mutate(weight_cumulative = weight / size_factor, size_factor = NULL) |>
   relocate(year, case_id, weight, weight_cumulative)
 
 
 # Write -----
 cli_alert_success("Finished combining, now saving")
-# write_rds(ccs, "data/temp_cc-name-cleaned-list.rds")
 save(i_rep, i_sen, i_gov, v_rep, v_sen, v_gov, file = "data/output/01_responses/vote_responses.RData")
 save(vv_party_gen, vv_party_prm, vv_regstatus, vv_turnout_gvm, vv_turnout_pvm, file = "data/output/01_responses/vv_responses.RData")
 write_feather(ccc_sort, "data/output/01_responses/cumulative_stacked.feather")
-# write_dta(ccc_sort, "~/Downloads/temp.dta")
 saveRDS(addon_id, "data/output/01_responses/addon_ids.Rds")
 write_csv(size_year, "data/output/03_contextual/weight_rescale_by-year.csv")
 

--- a/05_stack-cumulative.R
+++ b/05_stack-cumulative.R
@@ -75,31 +75,18 @@ wgt_post <- find_stack(ccs, weight_post, "numeric")
 vwgt <- find_stack(ccs, vvweight, "numeric")
 vwgt_post <- find_stack(ccs, vvweight_post, "numeric")
 
-tookpost <- find_stack(ccs, tookpost, make_labelled = FALSE, new_reorder = FALSE) |>
-  mutate(tookpost = labelled(
-    as.integer(tookpost_num == 1 & year < 2018 |
-                 tookpost_num == 2 & year %in% c(2018, 2020, 2022, 2024)), # diff number in 2018
-    labels = c("Took Post-Election Survey" = 1,
-               "Did Not Take Post-Election Survey" = 0))) |>
-  mutate(tookpost = replace(tookpost, year %% 2 == 1, NA)) |>
-  select(year, case_id, tookpost)
+tookpost_raw <- find_stack(ccs, tookpost, make_labelled = FALSE, new_reorder = FALSE)
+tookpost <- finalize_tookpost(tookpost_raw)
 
-time <- find_stack(ccs, starttime, type = "datetime") |>
-  filter(year != 2006, year != 2009) |>
-  bind_rows(cc06_time, cc09_time)
+time_raw <- find_stack(ccs, starttime, type = "datetime")
+time_fixed <- replace_year(time_raw, c(2006, 2009), bind_rows(cc06_time, cc09_time))
+time <- time_fixed
 
 ## pid -------
 cli_h1("Joining partisanship and demographics")
-pid3_labels <- c("Democrat" = 1, "Republican" = 2, "Independent" = 3,
-                 "Other" = 4, "Not Sure" = 5)
-
-pid3 <- find_stack(ccs, pid3, make_labelled = FALSE, new_reorder = FALSE) |>
-  filter(year != 2010) |> # fix the missing 2010
-  bind_rows(cc10_pid3) |>
-  mutate(pid3_num = na_if(pid3_num, 8)) |>
-  mutate(pid3_num = na_if(pid3_num, 9)) |>
-  mutate(pid3 = labelled(as.integer(pid3_num), pid3_labels)) |>
-  select(year, case_id, pid3) # manually do only this one
+pid3_raw <- find_stack(ccs, pid3, make_labelled = FALSE, new_reorder = FALSE)
+pid3_fixed <- replace_year(pid3_raw, 2010, cc10_pid3)
+pid3 <- finalize_pid3(pid3_fixed)
 
 pid7 <- find_stack(ccs, pid7, make_labelled = TRUE)
 
@@ -274,46 +261,19 @@ churatd <- find_stack(ccs, pew_churatd, make_labelled = TRUE) |>
 ## turnout ----
 cli_h1("Joining turnout")
 reg_self <- find_stack(ccs, reg_self)
-intent_turnout_levels <- c(
-  "Yes, definitely",
-  "Probably",
-  "I already voted (early or absentee)",
-  "I plan to vote before Election Day",
-  "No",
-  "Undecided"
-)
-intent_trn <- find_stack(ccs, intent_trn, type = "factor") |>
-  mutate(intent_turnout_self = replace_values(
-    as.character(intent_trn),
-    "Yes, Definitely"                      ~ "Yes, definitely",
-    "I Already Voted (Early or Absentee)"  ~ "I already voted (early or absentee)",
-    c("I Plan to Vote Before November 3rd",
-      "I Plan to Vote Before November 4th",
-      "I Plan to Vote Before November 5th",
-      "I Plan to Vote Before November 6th",
-      "I Plan to Vote Before November 8th") ~ "I plan to vote before Election Day"),
-    intent_turnout_self = factor(intent_turnout_self, levels = intent_turnout_levels))
+intent_trn_raw <- find_stack(ccs, intent_trn, type = "factor")
+intent_trn <- finalize_intent_turnout(intent_trn_raw)
 
-voted_trn <- find_stack(ccs, voted_trn, type = "factor") |>
-  mutate(voted_turnout_self = case_when(
-    str_detect(voted_trn, regex("Definitely Voted", ignore_case = TRUE)) ~ "Yes",
-    str_detect(voted_trn, regex("yes", ignore_case = TRUE)) ~ "Yes",
-    str_detect(voted_trn, regex("no", ignore_case = TRUE)) ~ "No",
-    str_detect(voted_trn, regex("not sure", ignore_case = TRUE)) ~ "Not Sure",
-    str_detect(voted_trn, regex("Did Not Vote", ignore_case = TRUE)) ~ "No",
-    str_detect(voted_trn, regex("didn't Vote", ignore_case = TRUE)) ~ "No",
-    str_detect(voted_trn, regex("But Didn't", ignore_case = TRUE)) ~ "No",
-    str_detect(voted_trn, regex("But couldn't", ignore_case = TRUE)) ~ "No",
-    str_detect(voted_trn, regex("But Did Not or Could Not", ignore_case = TRUE)) ~ "No",
-    TRUE ~ NA_character_)
-  ) |>
-  mutate(voted_turnout_self = fct_relevel(voted_turnout_self, "Yes", "No"))
+voted_trn_raw <- find_stack(ccs, voted_trn, type = "factor")
+voted_trn <- finalize_voted_turnout(voted_trn_raw)
 
 # checks before deleting
-count(intent_trn, intent_turnout_self, intent_trn)
-count(voted_trn, voted_turnout_self, voted_trn)
-voted_trn$voted_trn <- NULL
-intent_trn$intent_trn <- NULL
+intent_trn_raw |>
+  left_join(intent_trn, by = join_by(year, case_id), relationship = "one-to-one") |>
+  count(intent_turnout_self, intent_trn)
+voted_trn_raw |>
+  left_join(voted_trn, by = join_by(year, case_id), relationship = "one-to-one") |>
+  count(voted_turnout_self, voted_trn)
 
 ## validated vote turnout -----
 vv_regstatus <- find_stack(ccs, vv_regstatus, new_reorder = FALSE) # will reorder by frequency later
@@ -419,26 +379,11 @@ apvsen2 <- find_stack(ccs, approval_sen2, make_labelled = FALSE)
 apvgov <- find_stack(ccs, approval_gov, make_labelled = TRUE)
 
 ## economy -----
-econ_char <- find_stack(ccs, economy_retro, make_labelled = FALSE, new_reorder = FALSE) |>
-  mutate(economy_retro_char = replace_values(
-    economy_retro_char,
-    c("Gotten Worse", "Gotten Somewhat Worse")   ~ "Gotten Worse / Somewhat Worse",
-    c("Gotten Better", "Gotten Somewhat Better") ~ "Gotten Better / Somewhat Better")) |>
-  filter(year != 2009) |>
-  bind_rows(cc09_econ) |>
-  mutate(economy_retro_char = replace(economy_retro_char, economy_retro_num == 8, NA),
-         economy_retro_num  = na_if(economy_retro_num, 8),
-         economy_retro_char = str_to_lower(economy_retro_char),
-         economy_retro_char = str_replace(economy_retro_char, "^g", "G"),
-         economy_retro_char = str_replace(economy_retro_char, "^s", "S"),
-         economy_retro_char = str_replace(economy_retro_char, "^n", "N"),
-  )
-
-# correct to labelled
-econ_key <- deframe(distinct(select(econ_char, economy_retro_char, economy_retro_num)))
-econ <- econ_char |>
-  mutate(economy_retro = labelled(economy_retro_num, labels = econ_key)) |>
-  select(year, case_id, economy_retro)
+econ_raw <- find_stack(ccs, economy_retro, make_labelled = FALSE, new_reorder = FALSE)
+econ_fixed <- econ_raw |>
+  collapse_economy_retro() |>
+  replace_year(2009, cc09_econ)
+econ <- finalize_economy_retro(econ_fixed)
 
 
 ## news interest
@@ -460,13 +405,17 @@ st_post <- find_stack(ccs, st_post, "character")
 zipcode <- find_stack(ccs, zipcode, "character") |>
   mutate(zipcode = str_pad(zipcode, width = 5, pad = "0"))
 
-county_fips <- find_stack(ccs, county_fips, "numeric") |>
+county_fips_raw <- find_stack(ccs, county_fips, "numeric")
+county_fips_fixed <- county_fips_raw |>
   left_join2(cc17_county) |>
   mutate(county_fips = coalesce(county_fips, as.numeric(countyfips))) |>
-  select(-countyfips) |>
-  filter(year != 2007) |>
-  bind_rows(select(cc07, year, case_id, county_fips = CC06_V1004) |>
-              mutate_all(zap_labels))
+  select(-countyfips)
+county_fips <- replace_year(
+  county_fips_fixed,
+  2007,
+  select(cc07, year, case_id, county_fips = CC06_V1004) |>
+    mutate_all(zap_labels)
+)
 
 dist <- find_stack(ccs, dist, "integer")
 dist_up <- find_stack(ccs, dist_up, "integer")

--- a/07_merge-contextual_upload.R
+++ b/07_merge-contextual_upload.R
@@ -5,6 +5,13 @@ library(tigris)
 library(arrow)
 library(cli)
 
+# TEST-GUIDE mode: set CCES_TEST_GUIDE=1 (e.g. `CCES_TEST_GUIDE=1 Rscript 07_merge-contextual_upload.R`)
+# to write only data/release/cumulative_2006-2025.feather -- the single file the
+# guide (guide/guide_cumulative_2006-2025.qmd) reads -- and skip the slow xz .rds,
+# .dta, factor, and addon outputs. See the Save section below.
+test_guide <- Sys.getenv("CCES_TEST_GUIDE", "") != ""
+if (test_guide) cli_alert_info("Running 07 in TEST-GUIDE mode (guide feather only)")
+
 drop_post <- function(x) filter(x, !str_detect(dataset, "_post"))
 
 # apppend the candidatename-candidate party variables to the vote choice qs
@@ -245,62 +252,68 @@ ccc_df <- ccc_cand |>
   mutate(year = as.integer(year)) |>
   mutate_if(is.factor, fct_drop) # drop unused values
 
-# make char variables for IDs for Stata
-# coerce a few columns to factor so they export as categorical
-ccc_fac <- ccc_df |>
-  mutate(case_id = as.character(case_id)) |> # keep case_id as a string, not numeric
-  mutate_at(vars(matches("(_icpsr$|hisp_origin)")), as.character) |>
-  mutate_at(vars(matches("(^cong)")), as.factor)
-
-# FIPS-state key
-fips_key <- tigris::fips_codes |>
-  as_tibble() |>
-  transmute(st = state, state = state_name, st_fips = as.integer(state_code)) |>
-  distinct()
-
-fips_key_post <- rename(fips_key, st_post = st, state_post = state)
-
-ccc_factor <- ccc_fac |>
-  left_join(fips_key, by = join_by(state, st), relationship = "many-to-one") |>
-  mutate(state = labelled(st_fips, deframe(select(fips_key, state, st_fips))),
-         st = labelled(st_fips, deframe(select(fips_key, st, st_fips)))) |>
-  select(-st_fips) |>
-  left_join(fips_key_post, by = join_by(state_post, st_post), relationship = "many-to-one") |>
-  mutate(state_post = labelled(st_fips, deframe(select(fips_key_post, state_post, st_fips))),
-         st_post = labelled(st_fips, deframe(select(fips_key_post, st_post, st_fips)))) |>
-  select(-st_fips)
-
 # Save ---------
 cli_h1("Save Final data")
-# needed for CCES_representation (2025-09-19)
-write_feather(ccc_df, "data/release/cumulative_2006-2025_addon.feather")
 panel_ids <- mutate(panel_ids, year = as.integer(year), case_id = as.numeric(case_id))
 
+# The guide reads only this file, so it is always written first. TEST-GUIDE mode
+# stops here and skips the slow xz .rds, .dta, factor, and addon outputs.
 write_feather(anti_join(ccc_df, panel_ids, by = ids), "data/release/cumulative_2006-2025.feather")
-write_rds(anti_join(ccc_df, panel_ids, by = ids), "data/release/cumulative_2006-2025.rds", compress = "xz")
 
-# anti-join things not to put on dataverse (panel, module)
-panel_charid <- mutate(panel_ids, case_id = as.character(case_id)) # char id to match ccc_factor
+if (test_guide) {
+  cli_alert_success("TEST-GUIDE mode: wrote cumulative_2006-2025.feather only; skipped addon/rds/dta/factor outputs")
+} else {
+  # needed for CCES_representation (2025-09-19)
+  write_feather(ccc_df, "data/release/cumulative_2006-2025_addon.feather")
+  write_rds(anti_join(ccc_df, panel_ids, by = ids), "data/release/cumulative_2006-2025.rds", compress = "xz")
+
+  # make char variables for IDs for Stata
+  # coerce a few columns to factor so they export as categorical
+  ccc_fac <- ccc_df |>
+    mutate(case_id = as.character(case_id)) |> # keep case_id as a string, not numeric
+    mutate_at(vars(matches("(_icpsr$|hisp_origin)")), as.character) |>
+    mutate_at(vars(matches("(^cong)")), as.factor)
+
+  # FIPS-state key
+  fips_key <- tigris::fips_codes |>
+    as_tibble() |>
+    transmute(st = state, state = state_name, st_fips = as.integer(state_code)) |>
+    distinct()
+
+  fips_key_post <- rename(fips_key, st_post = st, state_post = state)
+
+  ccc_factor <- ccc_fac |>
+    left_join(fips_key, by = join_by(state, st), relationship = "many-to-one") |>
+    mutate(state = labelled(st_fips, deframe(select(fips_key, state, st_fips))),
+           st = labelled(st_fips, deframe(select(fips_key, st, st_fips)))) |>
+    select(-st_fips) |>
+    left_join(fips_key_post, by = join_by(state_post, st_post), relationship = "many-to-one") |>
+    mutate(state_post = labelled(st_fips, deframe(select(fips_key_post, state_post, st_fips))),
+           st_post = labelled(st_fips, deframe(select(fips_key_post, st_post, st_fips)))) |>
+    select(-st_fips)
+
+  # anti-join things not to put on dataverse (panel, module)
+  panel_charid <- mutate(panel_ids, case_id = as.character(case_id)) # char id to match ccc_factor
+
+  # write to dta after applying variable labels in 05
+  # remove panel cases
+  ccc_common <- anti_join(ccc_factor, panel_charid, by = c("year", "case_id"))
+
+  # Write to dta with var labels
+  for (v in colnames(ccc_common)) {
+    attributes(ccc_common[[v]])$label <- ccc_meta$name[which(ccc_meta$alias == v)]
+    attributes(ccc_df[[v]])$label <- ccc_meta$name[which(ccc_meta$alias == v)]
+  }
 
 
-# write to dta after applying variable labels in 05
-# remove panel cases
-ccc_common <- anti_join(ccc_factor, panel_charid, by = c("year", "case_id"))
+  if (nrow(ccc_common) > nrow(distinct(ccc_common, year, case_id)))
+    cli::cli_abort("Found Duplicate case IDs")
 
-# Write to dta with var labels
-for (v in colnames(ccc_common)) {
-  attributes(ccc_common[[v]])$label <- ccc_meta$name[which(ccc_meta$alias == v)]
-  attributes(ccc_df[[v]])$label <- ccc_meta$name[which(ccc_meta$alias == v)]
+  write_rds(ccc_common, "data/output/cumulative_2006-2025_factor.rds")
+  write_dta(ccc_common, "data/release/cumulative_2006-2025.dta", version = 14)
+
+  # NOTE: the Crunch.io upload step (disabled, not needed for the Dataverse release)
+  # was moved to older/07_crunch-upload.R (2026-06-26).
+
+  cat("Finished merging candidate vars and the rest. Updated Rds and dta.\n")
 }
-
-
-if (nrow(ccc_common) > nrow(distinct(ccc_common, year, case_id)))
-  cli::cli_abort("Found Duplicate case IDs")
-
-write_rds(ccc_common, "data/output/cumulative_2006-2025_factor.rds")
-write_dta(ccc_common, "data/release/cumulative_2006-2025.dta", version = 14)
-
-# NOTE: the Crunch.io upload step (disabled, not needed for the Dataverse release)
-# was moved to older/07_crunch-upload.R (2026-06-26).
-
-cat("Finished merging candidate vars and the rest. Updated Rds and dta.\n")

--- a/guide/guide_cumulative_2006-2025.qmd
+++ b/guide/guide_cumulative_2006-2025.qmd
@@ -1477,6 +1477,7 @@ Routine edits add new rows, add new variables, and change the customization of e
 - Adds odd-year governor vote choice, starting in 2013. (#61)
 - Adds 2008 values for individual union membership (#73, Brian Schaffner)
 - Standardizes the early-vote label in `intent_turnout_self` and excludes 2025 `CC25_363` because it asks about 2026 House intent rather than turnout intent. (#79)
+- Adds 2025 `vv_party_gen` values, including the new categories `No Party, Independent, Declined to State` and `Not Sure`. Because validated-vote party variables are ordered by frequency, these new categories shift the order of rarer `vv_party_gen` levels after `Other`.
   
 
 ### Version 11.0 (released `2025-10-08`)

--- a/guide/guide_cumulative_2006-2025.qmd
+++ b/guide/guide_cumulative_2006-2025.qmd
@@ -8,7 +8,7 @@ title: |
     | Guide to the Cumulative Common Content
     | of the Cooperative (Congressional) Election Study
 author: "Shiro Kuriwaki"
-thanks: "Department of Political Science, Yale University. Website: \\url{https://www.shirokuriwaki.com}. ORCID: \\url{https://orcid.org/0000-0002-5687-2647}. My thanks to Alexander Agadjanian, Jeremiah Cha, Steve Ansolabehere, Valerie Bradley, Stephen DiMauro, Bernard Fraga, Nathan Kaplan, Silvia Kim, Mayya Komisarchik, Stephen Pettigrew, Boris Shor, Brian Schaffner, Caroline Soler, and Gerlad Wright for finding errors and providing suggestions. Adam Chapnik contributed significantly to V12. Thanks to Joe Williams at YouGov, and Jon Keane,  Mike Malecki, and Gordon Shotwell at Crunch for their help."
+thanks: "Department of Political Science, Yale University. Website: \\url{https://www.shirokuriwaki.com}. ORCID: \\url{https://orcid.org/0000-0002-5687-2647}. My thanks to Alexander Agadjanian, Jeremiah Cha, Steve Ansolabehere, Valerie Bradley, Stephen DiMauro, Bernard Fraga, Nathan Kaplan, Silvia Kim, Mayya Komisarchik, Stephen Pettigrew, Boris Shor, Brian Schaffner, Caroline Soler, and Gerlad Wright for finding errors and providing suggestions. Adam Chapnik and Zoya Ahmer contributed significantly to V12. Thanks to Joe Williams at YouGov, and Jon Keane,  Mike Malecki, and Gordon Shotwell at Crunch for their help."
 date: "Guide last updated: `r Sys.Date()`"
 ---
 
@@ -31,7 +31,9 @@ library(rprojroot)
 
 ```{r, include = FALSE, cache = FALSE}
 tictoc::tic()
-cc <- arrow::read_feather(find_rstudio_root_file("data/release/cumulative_2006-2025.feather"))
+guide_data_path <- find_rstudio_root_file("data/release/cumulative_2006-2025.feather")
+guide_cache_path <- find_rstudio_root_file("data/output/02_questions/guide_summary_cache.rds")
+cc <- arrow::read_feather(guide_data_path)
 tictoc::toc()
 
 meta <- readRDS(find_rstudio_root_file("data/output/02_questions/cumulative_vartable.Rds"))
@@ -39,16 +41,91 @@ rsc <- read_csv(find_rstudio_root_file("data/output/03_contextual/weight_rescale
 ```
 
 ```{r}
-print_tab <- function(var, do_sort = FALSE, tbl = cc) {
+guide_fingerprint <- function(path) {
+  info <- file.info(path)
+  c(
+    path = normalizePath(path, mustWork = TRUE),
+    size = as.character(info$size),
+    mtime = as.character(as.numeric(info$mtime))
+  )
+}
+
+year_label <- function(yrs_vec) {
+  known <- list(
+    "All of 2006-2020" = 2006:2020,
+    "All of 2006-2025" = 2006:2025,
+    "All of 2006-2025 except 2007" = setdiff(c(2006:2025), 2007),
+    "All of 2007-2025" = 2007:2025,
+    "All of 2008-2025" = 2008:2025,
+    "All of 2009-2025" = 2009:2025
+  )
+  label <- names(keep(known, \(x) identical(x, yrs_vec)))
+  if (length(label) > 0) {
+    label[[1]]
+  } else {
+    str_c(yrs_vec, collapse = ", ")
+  }
+}
+
+guide_tab <- function(x) {
+  if (is.labelled(x)) x <- as_factor(x)
+  if (is.factor(x)) x <- fct_na_value_to_level(x, level = "(Missing)")
+
+  tibble(value = x) |>
+    count(value, name = "n") |>
+    mutate(value = as.character(value))
+}
+
+build_guide_cache <- function(tbl, source_path) {
+  list(
+    source = guide_fingerprint(source_path),
+    tabs = map(set_names(names(tbl)), \(v) guide_tab(tbl[[v]])),
+    years = map(set_names(names(tbl)), \(v) {
+      tbl |>
+        filter(!is.na(.data[[v]])) |>
+        distinct(year) |>
+        arrange(year) |>
+        pull(year) |>
+        zap_label() |>
+        year_label()
+    })
+  )
+}
+
+read_guide_cache <- function(tbl, source_path, cache_path) {
+  # Set CCES_FORCE_GUIDE_SUMMARY=1 to rebuild even when the feather fingerprint matches.
+  force_rebuild <- Sys.getenv("CCES_FORCE_GUIDE_SUMMARY", "") != ""
+  source <- guide_fingerprint(source_path)
+
+  if (!force_rebuild && file.exists(cache_path)) {
+    cache <- read_rds(cache_path)
+    if (identical(cache$source, source)) return(cache)
+  }
+
+  cache <- build_guide_cache(tbl, source_path)
+  write_rds(cache, cache_path)
+  cache
+}
+
+guide_summary <- read_guide_cache(cc, guide_data_path, guide_cache_path)
+
+print_tab <- function(var, do_sort = FALSE, tbl = NULL) {
   var <- enquo(var)
+  varchar <- quo_name(var)
   
-  tal <- tbl |> 
-    select(!!var) |> 
-    mutate_if(is.labelled, as_factor) |> 
-    mutate_if(is.factor, ~fct_na_value_to_level(.x, level = "(Missing)")) |> 
-    group_by(!!var) |> 
-    tally(sort = do_sort) |> 
-    mutate_at(vars(1), as.character)
+  if (is.null(tbl) && varchar %in% names(guide_summary$tabs)) {
+    tal <- guide_summary$tabs[[varchar]]
+    if (do_sort) tal <- arrange(tal, desc(n))
+  } else {
+    if (is.null(tbl)) tbl <- cc
+    tal <- tbl |> 
+      select(!!var) |> 
+      mutate_if(is.labelled, as_factor) |> 
+      mutate_if(is.factor, ~fct_na_value_to_level(.x, level = "(Missing)")) |> 
+      group_by(!!var) |> 
+      tally(sort = do_sort) |> 
+      mutate_at(vars(1), as.character)
+  }
   
   dframe <- as.data.frame(tal)
   
@@ -68,18 +145,25 @@ print_tab <- function(var, do_sort = FALSE, tbl = cc) {
 ```
 
 ```{r}
-print_numeric <- function(var, tbl = cc) {
+print_numeric <- function(var, tbl = NULL) {
   var <- enquo(var)
   
-  summary(pull(cc, !!var))
+  if (is.null(tbl)) tbl <- cc
+  summary(pull(tbl, !!var))
 }
 ```
 
 
 ```{r}
-in_years <- function(var, tbl = cc) {
+in_years <- function(var, tbl = NULL) {
   var <- enquo(var)
+  varchar <- quo_name(var)
+
+  if (is.null(tbl) && varchar %in% names(guide_summary$years)) {
+    return(guide_summary$years[[varchar]])
+  }
   
+  if (is.null(tbl)) tbl <- cc
   yrs_vec <- tbl |> 
     filter(!is.na(!!var)) |> 
     distinct(year) |> 
@@ -87,23 +171,7 @@ in_years <- function(var, tbl = cc) {
     pull() |> 
     zap_label()
   
-  if (identical(yrs_vec, 2006:2016)) return("All of 2006-2016")  
-  if (identical(yrs_vec, 2006:2017)) return("All of 2006-2017")  
-  if (identical(yrs_vec, 2006:2018)) return("All of 2006-2018")  
-  if (identical(yrs_vec, 2006:2019)) return("All of 2006-2019")  
-  if (identical(yrs_vec, 2006:2020)) return("All of 2006-2020")  
-  if (identical(yrs_vec, 2006:2022)) return("All of 2006-2022")  
-  if (identical(yrs_vec, 2008:2022)) return("All of 2008-2022")  
-  if (identical(yrs_vec, 2007:2025)) return("All of 2007-2025")  
-  if (identical(yrs_vec, 2006:2025)) return("All of 2006-2025")  
-  if (identical(yrs_vec, 2008:2025)) return("All of 2008-2025")  
-  if (identical(yrs_vec, 2009:2025)) return("All of 2009-2025")  
-  if (identical(yrs_vec, setdiff(c(2006:2025), 2007))) return("All of 2006-2025 except 2007")  
-  if (!(identical(yrs_vec, 2006:2019) | 
-        identical(yrs_vec, 2006:2018) | 
-        identical(yrs_vec, 2006:2017))) {
-    return(str_c(yrs_vec, collapse = ", "))
-  }
+  year_label(yrs_vec)
 }
 ```
 

--- a/guide/guide_cumulative_2006-2025.tex
+++ b/guide/guide_cumulative_2006-2025.tex
@@ -159,7 +159,7 @@ contributed significantly to V12. Thanks to Joe Williams at YouGov, and
 Jon Keane, Mike Malecki, and Gordon Shotwell at Crunch for their help.}}
 
 
-\date{2026-07-03}
+\date{2026-07-06}
 
 \begin{document}
 
@@ -3619,18 +3619,18 @@ description/metadata changes.
 \item
   For 2022 data, now uses an updated
   \href{https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/PR4L8P&version=4.0}{V4}
-  of the 2022 CCES cumulative file,
+  of the 2022 CCES cumulative file, which was updated in April 2024 to
+  fill missing county FIPS codes. This adds \texttt{county\_fips} for
+  131 rows (\textless{} 1 \% of 2022 data).
 \item
-  Add Governor vote choice even for odd years, starting from 2013.
-  (\#61)
+  Adds odd-year governor vote choice, starting in 2013. (\#61)
 \item
-  Add 2008 values for individual uninon membership (\#73, Brian
+  Adds 2008 values for individual union membership (\#73, Brian
   Schaffner)
 \item
-  Lower/upper case standardization for values in
-  \texttt{intent\_turnout\_self} (\#79) which was updated in April 2024
-  to fill missing county FIPS codes.　This adds \texttt{county\_fips}
-  for 131 rows (\textless{} 1 \% of 2022 data).
+  Standardizes the early-vote label in \texttt{intent\_turnout\_self}
+  and excludes 2025 \texttt{CC25\_363} because it asks about 2026 House
+  intent rather than turnout intent. (\#79)
 \end{itemize}
 
 \subsubsection{\texorpdfstring{Version 11.0 (released

--- a/guide/guide_cumulative_2006-2025.tex
+++ b/guide/guide_cumulative_2006-2025.tex
@@ -3631,6 +3631,12 @@ description/metadata changes.
   Standardizes the early-vote label in \texttt{intent\_turnout\_self}
   and excludes 2025 \texttt{CC25\_363} because it asks about 2026 House
   intent rather than turnout intent. (\#79)
+\item
+  Adds 2025 \texttt{vv\_party\_gen} values, including the new categories
+  \texttt{No\ Party,\ Independent,\ Declined\ to\ State} and
+  \texttt{Not\ Sure}. Because validated-vote party variables are ordered
+  by frequency, these new categories shift the order of rarer
+  \texttt{vv\_party\_gen} levels after \texttt{Other}.
 \end{itemize}
 
 \subsubsection{\texorpdfstring{Version 11.0 (released

--- a/guide/guide_cumulative_2006-2025.tex
+++ b/guide/guide_cumulative_2006-2025.tex
@@ -155,8 +155,9 @@ Agadjanian, Jeremiah Cha, Steve Ansolabehere, Valerie Bradley, Stephen
 DiMauro, Bernard Fraga, Nathan Kaplan, Silvia Kim, Mayya Komisarchik,
 Stephen Pettigrew, Boris Shor, Brian Schaffner, Caroline Soler, and
 Gerlad Wright for finding errors and providing suggestions. Adam Chapnik
-contributed significantly to V12. Thanks to Joe Williams at YouGov, and
-Jon Keane, Mike Malecki, and Gordon Shotwell at Crunch for their help.}}
+and Zoya Ahmer contributed significantly to V12. Thanks to Joe Williams
+at YouGov, and Jon Keane, Mike Malecki, and Gordon Shotwell at Crunch
+for their help.}}
 
 
 \date{2026-07-06}


### PR DESCRIPTION
Closes #69, #77, #80 following the strategies outlined in each of those issues.

Also makes 05 faster by working only with unique text values instead of passing an entire column through regex, and using a cache for the guide.